### PR TITLE
Removed 'Forgot Password?' link from login page

### DIFF
--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -10,5 +10,4 @@
   {{ form|crispy }}
   <button class="btn btn-success" type="submit">Log in</button>
 </form>
-<a href="{% url 'account_reset_password' %}">Forgot Password?</a>
 {% endblock content %}


### PR DESCRIPTION
This commit removes the 'Forgot Password?' link from the login page template. Previously, there were two password reset options available to users: a button within the login form and a separate link